### PR TITLE
Fix user model importer path

### DIFF
--- a/docs/import/users.md
+++ b/docs/import/users.md
@@ -7,7 +7,7 @@ Use the User Element Importer to import users.
 ``` json Craft 3
 [
   {
-    "@model": "barrelstrength\\sproutbaseimport\\importers\\elements\\User",
+    "@model": "barrelstrength\\sproutbase\\app\\import\\importers\\elements\\User",
     "attributes": {
       "username": "beryl01",
       "firstName": "Luigi",
@@ -33,7 +33,7 @@ To assign a user to the Admin group, use the `admin` attribute.
 ``` json Craft 3
 [
   {
-    "@model": "barrelstrength\\sproutbaseimport\\importers\\elements\\User",
+    "@model": "barrelstrength\\sproutbase\\app\\import\\importers\\elements\\User",
     "attributes": {
       "username": "beryl01",
       "firstName": "Luigi",


### PR DESCRIPTION
I'm sure there are other paths that are incorrect in the docs, but wanted to point out this specific one since I was working on importing users.